### PR TITLE
feat: improve skill scores for autonomous-dev

### DIFF
--- a/plugins/autonomous-dev/skills/api-design/SKILL.md
+++ b/plugins/autonomous-dev/skills/api-design/SKILL.md
@@ -1,24 +1,12 @@
 ---
 name: api-design
 description: "REST API design best practices covering versioning, error handling, pagination, and OpenAPI documentation. Use when designing or implementing REST APIs or HTTP endpoints. TRIGGER when: API design, REST endpoint, HTTP route, OpenAPI, swagger, pagination. DO NOT TRIGGER when: internal library code, CLI tools, non-HTTP interfaces."
-allowed-tools: [Read]
+allowed-tools: "Read"
 ---
 
 # API Design Skill
 
-REST API design best practices, HTTP conventions, versioning, error handling, and documentation standards.
-
-## When This Skill Activates
-
-- Designing REST APIs
-- Creating HTTP endpoints
-- Writing API documentation
-- Handling API errors
-- Implementing pagination
-- API versioning strategies
-- Keywords: "api", "rest", "endpoint", "http", "json", "openapi"
-
----
+Project conventions for REST API design, error handling, versioning, and documentation.
 
 ## Core Concepts
 
@@ -36,27 +24,7 @@ RESTful resource design using nouns (not verbs), proper HTTP methods, and hierar
 
 ---
 
-### 2. HTTP Status Codes
-
-Proper status code usage for success (2xx), client errors (4xx), and server errors (5xx).
-
-**Common Codes**:
-- **200 OK**: Successful GET/PUT/PATCH
-- **201 Created**: Successful POST (includes Location header)
-- **204 No Content**: Successful DELETE
-- **400 Bad Request**: Invalid input
-- **401 Unauthorized**: Authentication required
-- **403 Forbidden**: Authenticated but not allowed
-- **404 Not Found**: Resource doesn't exist
-- **422 Unprocessable**: Validation error
-- **429 Too Many Requests**: Rate limit exceeded
-- **500 Internal Server Error**: Server failure
-
-**See**: `docs/http-status-codes.md` for complete reference and examples
-
----
-
-### 3. Error Handling
+### 2. Error Handling
 
 RFC 7807 Problem Details format for consistent, structured error responses.
 
@@ -207,90 +175,43 @@ Idempotency, content negotiation, HATEOAS, bulk operations, and webhooks.
 
 ---
 
-## Quick Reference
+## API Design Workflow
 
-| Pattern | Use Case | Details |
-|---------|----------|---------|
-| REST Principles | Resource-based URLs | `docs/rest-principles.md` |
-| Status Codes | HTTP response codes | `docs/http-status-codes.md` |
-| Error Handling | RFC 7807 errors | `docs/error-handling.md` |
-| Pagination | Large datasets | `docs/pagination.md` |
-| Versioning | Breaking changes | `docs/versioning.md` |
-| Authentication | API security | `docs/authentication.md` |
-| Rate Limiting | Abuse prevention | `docs/rate-limiting.md` |
-| Documentation | OpenAPI/Swagger | `docs/documentation.md` |
-
----
-
-## API Design Checklist
-
-**Before Launch**:
-- [ ] Use RESTful resource naming (nouns, not verbs)
-- [ ] Implement proper HTTP status codes
-- [ ] Add RFC 7807 error responses
-- [ ] Include pagination for collections
-- [ ] Add API versioning strategy
-- [ ] Implement authentication
-- [ ] Add rate limiting
-- [ ] Configure CORS (if browser clients)
-- [ ] Generate OpenAPI documentation
-- [ ] Test idempotency for POST/PUT/DELETE
+1. **Define resources** — identify nouns and relationships (`/users`, `/users/{id}/posts`)
+2. **Design endpoints** — map CRUD to HTTP methods, keep URLs max 3 levels deep
+3. **Implement error handling** — RFC 7807 format on all endpoints
+4. **Add pagination** — offset or cursor-based on all collection endpoints
+5. **Version the API** — URL path versioning (`/v1/`)
+6. **Secure endpoints** — authentication (API key or JWT) + rate limiting
+7. **Generate documentation** — OpenAPI spec, verify all endpoints documented
+8. **Validate** — test idempotency for POST/PUT/DELETE, verify CORS if browser clients
 
 **See**: `docs/patterns-checklist.md` for complete checklist
 
 ---
 
-## Progressive Disclosure
+## Reference Documentation
 
-This skill uses progressive disclosure to prevent context bloat:
-
-- **Index** (this file): High-level concepts and quick reference (<500 lines)
-- **Detailed docs**: `docs/*.md` files with implementation details (loaded on-demand)
-
-**Available Documentation**:
-- `docs/rest-principles.md` - RESTful design patterns
-- `docs/http-status-codes.md` - Complete status code reference
-- `docs/error-handling.md` - Error response patterns
-- `docs/request-response-format.md` - JSON structure conventions
-- `docs/pagination.md` - Pagination strategies
-- `docs/versioning.md` - API versioning patterns
-- `docs/authentication.md` - Authentication methods
-- `docs/rate-limiting.md` - Rate limiting implementation
-- `docs/advanced-features.md` - CORS, filtering, sorting
-- `docs/documentation.md` - OpenAPI/Swagger
-- `docs/idempotency-content-negotiation.md` - Advanced patterns
-- `docs/patterns-checklist.md` - Design checklist and common patterns
-
----
+| Topic | File |
+|-------|------|
+| REST principles | `docs/rest-principles.md` |
+| Status codes | `docs/http-status-codes.md` |
+| Error handling | `docs/error-handling.md` |
+| Request/response format | `docs/request-response-format.md` |
+| Pagination | `docs/pagination.md` |
+| Versioning | `docs/versioning.md` |
+| Authentication | `docs/authentication.md` |
+| Rate limiting | `docs/rate-limiting.md` |
+| CORS, filtering, sorting | `docs/advanced-features.md` |
+| OpenAPI/Swagger | `docs/documentation.md` |
+| Idempotency, HATEOAS, webhooks | `docs/idempotency-content-negotiation.md` |
+| Full checklist | `docs/patterns-checklist.md` |
 
 ## Cross-References
 
-**Related Skills**:
-- **error-handling-patterns** - Error handling best practices
-- **security-patterns** - API security hardening
-- **python-standards** - Python API implementation and documentation standards
-
-**Related Libraries**:
-- FastAPI - Python API framework with auto-documentation
-- Pydantic - Data validation and serialization
-- JWT libraries - Token-based authentication
-
----
-
-## Key Takeaways
-
-1. **Resources are nouns**: `/users`, not `/getUsers`
-2. **Use HTTP methods correctly**: GET (read), POST (create), PUT (replace), DELETE (remove)
-3. **Return proper status codes**: 200 (success), 201 (created), 404 (not found), 422 (validation error)
-4. **Structured errors**: Use RFC 7807 format
-5. **Paginate collections**: Offset or cursor-based
-6. **Version your API**: URL path versioning (e.g., `/v1/users`)
-7. **Secure endpoints**: API keys or JWT
-8. **Rate limit**: Prevent abuse
-9. **Document thoroughly**: OpenAPI/Swagger
-10. **Test idempotency**: Safe retries for POST/PUT/DELETE
-
----
+- [error-handling](../error-handling/SKILL.md) — Error handling best practices
+- [security-patterns](../security-patterns/SKILL.md) — API security hardening
+- [python-standards](../python-standards/SKILL.md) — Python API implementation standards
 
 ## Hard Rules
 
@@ -301,7 +222,7 @@ This skill uses progressive disclosure to prevent context bloat:
 - Endpoints that accept unbounded input without pagination or limits
 
 **REQUIRED**:
-- All endpoints MUST have consistent error response format (`{error, message, code}`)
+- All endpoints MUST use RFC 7807 Problem Details error format
 - All collection endpoints MUST support pagination
 - All mutations MUST be idempotent or explicitly documented as non-idempotent
 - Rate limiting MUST be documented in API specification

--- a/plugins/autonomous-dev/skills/code-review/SKILL.md
+++ b/plugins/autonomous-dev/skills/code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-review
 description: "10-point code review checklist covering correctness, tests, error handling, type hints, naming, security, and performance. Use when reviewing PRs or evaluating code quality. TRIGGER when: code review, PR review, review checklist, code quality check. DO NOT TRIGGER when: writing new code, debugging, refactoring without review context."
-allowed-tools: [Read, Grep, Glob, Bash]
+allowed-tools: "Read, Grep, Glob, Bash"
 ---
 
 # Code Review Enforcement Skill
@@ -135,13 +135,12 @@ Every review MUST conclude with exactly one of:
 
 ---
 
-## Anti-Patterns
+## Example
 
 ### BAD: Rubber-stamp approval
 ```
 "Looks good to me, ship it!"
 ```
-Missing: checklist, line references, test results, security review.
 
 ### GOOD: Structured review
 ```
@@ -159,16 +158,10 @@ Missing: checklist, line references, test results, security review.
 ### Verdict: REQUEST_CHANGES
 ```
 
-### BAD: Nitpicking style, missing logic bugs
-Spending 10 comments on variable naming while an off-by-one error goes unnoticed.
-
-### BAD: "Will fix later" acceptance
-Approving with known BLOCKING issues and a verbal promise to fix. If it is BLOCKING, it blocks.
-
 ---
 
 ## Cross-References
 
-- **python-standards**: Style and type hint requirements
-- **testing-guide**: Test coverage expectations
-- **security-patterns**: Security checklist details
+- [python-standards](../python-standards/SKILL.md) — Style and type hint requirements
+- [testing-guide](../testing-guide/SKILL.md) — Test coverage expectations
+- [security-patterns](../security-patterns/SKILL.md) — Security checklist details

--- a/plugins/autonomous-dev/skills/debugging-workflow/SKILL.md
+++ b/plugins/autonomous-dev/skills/debugging-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: debugging-workflow
 description: "Systematic debugging methodology — reproduce, isolate, bisect, fix, verify. Use when diagnosing failures, tracing errors, or investigating unexpected behavior. TRIGGER when: debug, error, traceback, stack trace, bisect, breakpoint, failing test, unexpected behavior. DO NOT TRIGGER when: writing new features, code review, documentation, refactoring."
-allowed-tools: [Read, Grep, Glob, Bash]
+allowed-tools: "Read, Grep, Glob, Bash"
 ---
 
 # Debugging Workflow
@@ -125,12 +125,7 @@ python -m pytest --cov=module --cov-report=term-missing tests/path/test_file.py
 3. Is there a regression test for this bug? → Must be YES
 4. Could this bug occur elsewhere? → Search for similar patterns
 
-## Common Pitfalls
+## Cross-References
 
-| Pitfall | Why It's Wrong | What To Do Instead |
-|---------|---------------|-------------------|
-| Fix without reproducing | You might fix the wrong thing | Always reproduce first |
-| Fix the symptom | Bug will recur in different form | Find root cause |
-| Large refactor as "fix" | Introduces new bugs | Minimal change only |
-| No regression test | Bug will come back | Test is part of the fix |
-| Skip full test suite | Fix broke something else | Always run full suite |
+- [testing-guide](../testing-guide/SKILL.md) — Test patterns for regression tests
+- [error-handling](../error-handling/SKILL.md) — Error handling patterns

--- a/plugins/autonomous-dev/skills/python-standards/SKILL.md
+++ b/plugins/autonomous-dev/skills/python-standards/SKILL.md
@@ -1,23 +1,12 @@
 ---
 name: python-standards
-description: "Python code quality standards covering PEP 8, Black formatting, type hints, Google-style docstrings, and error handling. Use when writing or reviewing Python code. TRIGGER when: python, formatting, type hints, docstrings, PEP 8, black, isort. DO NOT TRIGGER when: non-Python files, markdown, config, shell scripts."
-allowed-tools: [Read]
+description: "Enforces PEP 8 compliance, applies Black formatting, validates type hints, generates Google-style docstrings, and implements error handling patterns. Use when writing or reviewing Python code. TRIGGER when: python, formatting, type hints, docstrings, PEP 8, black, isort. DO NOT TRIGGER when: non-Python files, markdown, config, shell scripts."
+allowed-tools: "Read"
 ---
 
 # Python Standards Skill
 
 Python code quality standards for autonomous-dev project.
-
-
-## When This Activates
-
-- Writing Python code
-- Code formatting
-- Type hints
-- Docstrings
-- Keywords: "python", "format", "type", "docstring"
-
----
 
 ## Code Style (PEP 8 + Black)
 
@@ -28,16 +17,9 @@ Python code quality standards for autonomous-dev project.
 | Quotes | Double quotes |
 | Imports | Sorted with isort |
 
-```bash
-black --line-length=100 src/ tests/
-isort --profile=black --line-length=100 src/ tests/
-```
-
----
-
 ## Type Hints (Required)
 
-**Rule:** All public functions must have type hints on parameters and return.
+All public functions must have type hints on parameters and return:
 
 ```python
 def process_file(
@@ -46,15 +28,13 @@ def process_file(
     *,
     max_lines: int = 1000
 ) -> Dict[str, any]:
-    """Type hints on all parameters and return."""
+    """Process and return file contents."""
     pass
 ```
 
----
-
 ## Docstrings (Google Style)
 
-**Rule:** All public functions/classes need docstrings with Args, Returns, Raises.
+All public functions/classes need docstrings with Args, Returns, Raises:
 
 ```python
 def process_data(data: List[Dict], *, batch_size: int = 32) -> ProcessResult:
@@ -72,27 +52,19 @@ def process_data(data: List[Dict], *, batch_size: int = 32) -> ProcessResult:
     """
 ```
 
----
-
 ## Error Handling
 
-**Rule:** Error messages must include context + expected + docs link.
+Every error message must include context, expected state, and docs link:
 
 ```python
-# ✅ GOOD
 raise FileNotFoundError(
     f"Config file not found: {path}\n"
     f"Expected: YAML with keys: model, data\n"
     f"See: docs/guides/configuration.md"
 )
-
-# ❌ BAD
-raise FileNotFoundError("File not found")
 ```
 
 ### Exception Hierarchy
-
-Define a project-level exception hierarchy for structured error handling:
 
 ```python
 class AppError(Exception):
@@ -112,30 +84,11 @@ class ExternalServiceError(AppError):
     pass
 ```
 
-**When to use custom vs built-in exceptions:**
-- Use **built-in** (`ValueError`, `TypeError`, `FileNotFoundError`) for standard programming errors
-- Use **custom** exceptions when callers need to catch specific application-level failures
-- Always inherit from a project base exception for catch-all handling
-
-### Error Message Format
-
-Every error message should follow this three-part format:
-
-1. **Context** - What happened and where
-2. **Expected** - What was expected instead
-3. **Docs link** - Where to find more information
-
-```python
-raise ValidationError(
-    f"Invalid config key '{key}' in {config_path}\n"
-    f"Expected one of: {', '.join(valid_keys)}\n"
-    f"See: docs/configuration.md#valid-keys"
-)
-```
+Use built-in exceptions (`ValueError`, `TypeError`, `FileNotFoundError`) for standard programming errors. Use custom exceptions when callers need to catch specific application-level failures.
 
 ### Graceful Degradation
 
-When a non-critical operation fails, log and continue rather than crashing:
+When a non-critical operation fails, log and continue:
 
 ```python
 try:
@@ -144,8 +97,6 @@ except CacheError:
     logging.warning("Cache unavailable, proceeding without cache")
     optional_result = None
 ```
-
----
 
 ## Naming Conventions
 
@@ -156,55 +107,34 @@ except CacheError:
 | Constants | UPPER_SNAKE | `MAX_LENGTH` |
 | Private | _underscore | `_helper()` |
 
----
-
 ## Best Practices
 
-1. **Keyword-only args** - Use `*` for clarity
-2. **Pathlib** - Use `Path` not string paths
-3. **Context managers** - Use `with` for resources
-4. **Dataclasses** - For configuration objects
+1. **Keyword-only args** — use `*` separator for functions with 2+ optional params
+2. **Pathlib** — use `Path` not string paths
+3. **Context managers** — use `with` for resources
+4. **Dataclasses** — for configuration objects
 
-```python
-# Keyword-only args
-def train(data: List, *, learning_rate: float = 1e-4):
-    pass
+## Quality Check Workflow
 
-# Pathlib
-config = Path("config.yaml").read_text()
-```
-
----
-
-## Code Quality Commands
+Run in this order before committing:
 
 ```bash
-flake8 src/ --max-line-length=100       # Linting
-mypy src/[project_name]/                # Type checking
-pytest --cov=src --cov-fail-under=80    # Coverage
+# 1. Format
+black --line-length=100 src/ tests/
+# 2. Sort imports
+isort --profile=black --line-length=100 src/ tests/
+# 3. Lint
+flake8 src/ --max-line-length=100
+# 4. Type check
+mypy src/[project_name]/
+# 5. Test with coverage
+pytest --cov=src --cov-fail-under=80
 ```
 
----
+## Cross-References
 
-## Key Takeaways
-
-1. **Type hints** - Required on all public functions
-2. **Docstrings** - Google style, with Args/Returns/Raises
-3. **Black formatting** - 100 char line length
-4. **isort imports** - Sorted and organized
-5. **Helpful errors** - Context + expected + docs link
-6. **Pathlib** - Use Path not string paths
-7. **Keyword args** - Use `*` for clarity
-8. **Dataclasses** - For configuration objects
-
----
-
-## Related Skills
-
-- **testing-guide** - Testing patterns and TDD methodology
-- **error-handling-patterns** - Error handling best practices
-
----
+- [testing-guide](../testing-guide/SKILL.md) — Testing patterns and TDD methodology
+- [error-handling](../error-handling/SKILL.md) — Error handling best practices
 
 ## Hard Rules
 

--- a/plugins/autonomous-dev/skills/testing-guide/SKILL.md
+++ b/plugins/autonomous-dev/skills/testing-guide/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: testing-guide
 description: "GenAI-first testing with structural assertions, congruence validation, and tier-based test structure. Use when writing tests, setting up test infrastructure, or validating coverage. TRIGGER when: test, pytest, coverage, TDD, test patterns, congruence, validation. DO NOT TRIGGER when: production code implementation, documentation, config-only changes."
-allowed-tools: [Read, Grep, Glob, Bash]
+allowed-tools: "Read, Grep, Glob, Bash"
 ---
 
 # Testing Guide


### PR DESCRIPTION
Hey @akaszubski 👋

An 8-agent pipeline that enforces alignment checks, adversarial code review, and security audits before a single line ships, v3.51 with 1,000+ commits shows this isn't a weekend experiment. The PROJECT.md-as-contract pattern is clever. Wanted to suggest a few improvements to the SKILL.md.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| api-design | 74% | 83% | +9% |
| python-standards | 82% | 89% | +7% |
| code-review | 90% | 93% | +3% |
| debugging-workflow | 90% | 90% | — |
| testing-guide | 86% | 86% | — |

<details>
<summary>What changed and why</summary>

### api-design (+9%)
- Removed redundant "When This Skill Activates" section (duplicates frontmatter description triggers)
- Removed HTTP status codes listing (Claude already knows standard codes)
- Removed "Key Takeaways" section (duplicated Core Concepts)
- Removed "Progressive Disclosure" meta-section explaining the file's own structure
- Consolidated "Quick Reference" table and "Available Documentation" list into a single "Reference Documentation" table
- Added sequenced "API Design Workflow" section (8-step process) to address missing workflow clarity
- Fixed error format inconsistency in Hard Rules (`{error, message, code}` → RFC 7807 to match the Error Handling section)
- Added file paths to cross-references for navigability
- Removed "Related Libraries" section (generic knowledge)

### python-standards (+7%)
- Improved description specificity with concrete action verbs ("Enforces PEP 8 compliance, applies Black formatting...")
- Removed redundant "When This Activates" section (duplicates frontmatter)
- Removed "Key Takeaways" section (duplicated earlier content)
- Consolidated duplicate error message format documentation
- Added sequenced "Quality Check Workflow" with numbered steps (format → sort → lint → type check → test)
- Added file paths to cross-references

### code-review (+3%)
- Deduplicated anti-patterns section (removed entries that restated HARD GATE rules)
- Added actual file paths to cross-references (`../python-standards/SKILL.md` instead of bare names)

### debugging-workflow (0%)
- Replaced redundant "Common Pitfalls" table (duplicated guidance from Phase 1 anti-patterns and Phase 4 rules) with cross-references to related skills

### testing-guide (0%)
- Fixed `allowed-tools` frontmatter format only (content was already strong at 86%)

### All skills
- Fixed `allowed-tools` frontmatter from YAML array syntax (`[Read]` / `[Read, Grep, Glob, Bash]`) to required string format (`"Read"` / `"Read, Grep, Glob, Bash"`)

</details>

Honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at this Tessl guide (https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - @yogesh-tessl (https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏
